### PR TITLE
Video post player[].embed_code from string or bool

### DIFF
--- a/post.go
+++ b/post.go
@@ -178,8 +178,8 @@ type VideoPost struct {
 	Html5Capable bool   `json:"html5_capable"`
 	PermalinkUrl string `json:"permalink_url"`
 	Players      []struct {
-		EmbedCode string      `json:"embed_code"`
-		Width     interface{} `json:"width"`
+		EmbedCode StringOrBool `json:"embed_code"`
+		Width     interface{}  `json:"width"`
 	} `json:"player"`
 	ThumbnailHeight uint32 `json:"thumbnail_height"`
 	ThumbnailUrl    string `json:"thumbnail_url"`
@@ -211,6 +211,28 @@ type PhotoSize struct {
 	Height uint32 `json:"height"`
 	Width  uint32 `json:"width"`
 	Url    string `json:"url"`
+}
+
+// StringOrBool is a string that can be unmarshalled from a string or a boolean value.
+type StringOrBool string
+
+// UnmarshalJSON implements the json.Unmarshaler interface to ingest strings or boolean values.
+func (sb *StringOrBool) UnmarshalJSON(b []byte) error {
+	if b[0] == '"' {
+		return json.Unmarshal(b, (*string)(sb))
+	}
+
+	var bl bool
+	if err := json.Unmarshal(b, &bl); err != nil {
+		return err
+	}
+
+	if bl {
+		*sb = StringOrBool("true")
+	} else {
+		*sb = StringOrBool("false")
+	}
+	return nil
 }
 
 // Convenience method for ease of use- renders a Post as a JSON string

--- a/post.go
+++ b/post.go
@@ -4,17 +4,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
 	"net/url"
+	"reflect"
 )
 
 // Representation of a list of Posts
 type Posts struct {
-	client ClientInterface
-	response Response
+	client      ClientInterface
+	response    Response
 	parsedPosts []PostInterface
-	Posts []MiniPost `json:"posts"`
-	TotalPosts int64 `json:"total_posts"`
+	Posts       []MiniPost `json:"posts"`
+	TotalPosts  int64      `json:"total_posts"`
 }
 
 // Method to retrieve fully fleshed post data from stubs and cache result
@@ -23,8 +23,8 @@ func (p *Posts) All() ([]PostInterface, error) {
 	if p.parsedPosts == nil {
 		r := struct {
 			Response struct {
-					 Posts []PostInterface `json:"posts"`
-				 } `json:"response"`
+				Posts []PostInterface `json:"posts"`
+			} `json:"response"`
 		}{}
 		r.Response.Posts = makePostsFromMinis(p.Posts, p.client)
 		if err = json.Unmarshal(p.response.body, &r); err != nil {
@@ -37,8 +37,8 @@ func (p *Posts) All() ([]PostInterface, error) {
 }
 
 // Method to retrieve a single Post entity at a given index; returns nil if index is out of bounds
-func (p *Posts) Get(index uint) (PostInterface) {
-	if posts,err := p.All(); err == nil {
+func (p *Posts) Get(index uint) PostInterface {
+	if posts, err := p.All(); err == nil {
 		if index >= uint(len(posts)) {
 			return nil
 		}
@@ -49,9 +49,9 @@ func (p *Posts) Get(index uint) (PostInterface) {
 
 // The basics for what is needed in a Post
 type MiniPost struct {
-	Id uint64 `json:"id"`
-	Type string `json:"type"`
-	BlogName string `json:"blog_name"`
+	Id        uint64 `json:"id"`
+	Type      string `json:"type"`
+	BlogName  string `json:"blog_name"`
 	ReblogKey string `json:"reblog_key"`
 }
 
@@ -64,71 +64,71 @@ type PostRef struct {
 // The common fields on any post, no matter what type
 type Post struct {
 	PostRef
-	Body string `json:"body"`
-	CanLike bool `json:"can_like"`
-	CanReblog bool `json:"can_reblog"`
-	CanReply bool `json:"can_reply"`
-	CanSendInMessage bool `json:"can_send_in_message"`
-	Caption string `json:"caption"`
-	Date string `json:"date"`
-	DisplayAvatar bool `json:"display_avatar"`
-	Followed bool `json:"followed"`
-	Format string `json:"format"`
-	Highlighted []interface{} `json:"highlighted"`
-	Liked bool `json:"liked"`
-	NoteCount uint64 `json:"note_count"`
-	PermalinkUrl string `json:"permalink_url"`
-	PostUrl string `json:"post_url"`
-	Reblog struct {
-		 Comment string `json:"comment"`
-		 TreeHTML string `json:"tree_html"`
-	       } `json:"reblog"`
-	RecommendedColor string `json:"recommended_color"`
-	RecommendedSource bool `json:"recommended_source"`
-	ShortUrl string `json:"short_url"`
-	Slug string `json:"slug"`
-	SourceTitle string `json:"source_title"`
-	SourceUrl string `json:"source_url"`
-	State string `json:"state"`
-	Summary string `json:"summary"`
-	Tags []string `json:"tags"`
-	Timestamp uint64 `json:"timestamp"`
-	FeaturedTimestamp uint64 `json:"featured_timestamp,omitempty"`
-	TrackName string `json:"track_name,omitempty"`
-	Trail []ReblogTrailItem `json:"trail"`
+	Body             string        `json:"body"`
+	CanLike          bool          `json:"can_like"`
+	CanReblog        bool          `json:"can_reblog"`
+	CanReply         bool          `json:"can_reply"`
+	CanSendInMessage bool          `json:"can_send_in_message"`
+	Caption          string        `json:"caption"`
+	Date             string        `json:"date"`
+	DisplayAvatar    bool          `json:"display_avatar"`
+	Followed         bool          `json:"followed"`
+	Format           string        `json:"format"`
+	Highlighted      []interface{} `json:"highlighted"`
+	Liked            bool          `json:"liked"`
+	NoteCount        uint64        `json:"note_count"`
+	PermalinkUrl     string        `json:"permalink_url"`
+	PostUrl          string        `json:"post_url"`
+	Reblog           struct {
+		Comment  string `json:"comment"`
+		TreeHTML string `json:"tree_html"`
+	} `json:"reblog"`
+	RecommendedColor  string            `json:"recommended_color"`
+	RecommendedSource bool              `json:"recommended_source"`
+	ShortUrl          string            `json:"short_url"`
+	Slug              string            `json:"slug"`
+	SourceTitle       string            `json:"source_title"`
+	SourceUrl         string            `json:"source_url"`
+	State             string            `json:"state"`
+	Summary           string            `json:"summary"`
+	Tags              []string          `json:"tags"`
+	Timestamp         uint64            `json:"timestamp"`
+	FeaturedTimestamp uint64            `json:"featured_timestamp,omitempty"`
+	TrackName         string            `json:"track_name,omitempty"`
+	Trail             []ReblogTrailItem `json:"trail"`
 }
 
 // Post substructure
 type ReblogTrailItem struct {
-	Blog Blog `json:"blog"`
-	Content string `json:"content"`
-	ContentRaw string `json:"content_raw"`
-	IsCurrentItem bool `json:"is_current_item"`
-	Post struct {
-		     // sometimes an actual int, sometimes a numeric string, always a headache
-		     Id interface{} `json:"id"`
-	     } `json:"post"`
+	Blog          Blog   `json:"blog"`
+	Content       string `json:"content"`
+	ContentRaw    string `json:"content_raw"`
+	IsCurrentItem bool   `json:"is_current_item"`
+	Post          struct {
+		// sometimes an actual int, sometimes a numeric string, always a headache
+		Id interface{} `json:"id"`
+	} `json:"post"`
 }
 
 // PostInterface for use in typed structures which could contain any of the below subtypes
 type PostInterface interface {
 	GetProperty(key string) (interface{}, error)
-	GetSelf() (*Post)
+	GetSelf() *Post
 }
 
 // Post subtype
 type QuotePost struct {
 	Post
 	Source string `json:"source,omitempty"`
-	Text string `json:"text"`
+	Text   string `json:"text"`
 }
 
 // Post subtype
 type ChatPost struct {
 	Post
-	Dialog []struct{
-		Label string `json:"label"`
-		Name string `json:"name"`
+	Dialog []struct {
+		Label  string `json:"label"`
+		Name   string `json:"name"`
 		Phrase string `json:"phrase"`
 	} `json:"dialog"`
 }
@@ -143,50 +143,50 @@ type TextPost struct {
 type LinkPost struct {
 	Post
 	Description string `json:"description"`
-	Excerpt string `json:"excerpt"`
-	LinkAuthor string `json:"link_author"`
-	Title string `json:"title"`
-	Url string `json:"url"`
+	Excerpt     string `json:"excerpt"`
+	LinkAuthor  string `json:"link_author"`
+	Title       string `json:"title"`
+	Url         string `json:"url"`
 }
 
 // Post subtype
 type AnswerPost struct {
 	Post
-	Answer string `json:"answer"`
+	Answer     string `json:"answer"`
 	AskingName string `json:"asking_name"`
-	AskingUrl string `json:"asking_url"`
-	Publisher string `json:"publisher"`
-	Question string `json:"question"`
+	AskingUrl  string `json:"asking_url"`
+	Publisher  string `json:"publisher"`
+	Question   string `json:"question"`
 }
 
 // Post subtype
 type AudioPost struct {
 	Post
-	AlbumArt string `json:"album_art"`
-	Artist string `json:"artist"`
+	AlbumArt       string `json:"album_art"`
+	Artist         string `json:"artist"`
 	AudioSourceUrl string `json:"audio_source_url"`
-	AudioType string `json:"audio_type"`
-	AudioUrl string `json:"audio_url"`
-	Embed string `json:"embed"`
-	Player string `json:"player"`
-	Plays uint64 `json:"plays"`
+	AudioType      string `json:"audio_type"`
+	AudioUrl       string `json:"audio_url"`
+	Embed          string `json:"embed"`
+	Player         string `json:"player"`
+	Plays          uint64 `json:"plays"`
 }
 
 // Post subtype
 type VideoPost struct {
 	Post
-	Html5Capable bool `json:"html5_capable"`
+	Html5Capable bool   `json:"html5_capable"`
 	PermalinkUrl string `json:"permalink_url"`
-	Players []struct {
-		EmbedCode string `json:"embed_code"`
-		Width interface{} `json:"width"`
+	Players      []struct {
+		EmbedCode string      `json:"embed_code"`
+		Width     interface{} `json:"width"`
 	} `json:"player"`
 	ThumbnailHeight uint32 `json:"thumbnail_height"`
-	ThumbnailUrl string `json:"thumbnail_url"`
-	ThumbnailWidth uint32 `json:"thumbnail_width"`
-	Video map[string]struct {
-		Height uint32 `json:"height"`
-		Width uint32 `json:"width"`
+	ThumbnailUrl    string `json:"thumbnail_url"`
+	ThumbnailWidth  uint32 `json:"thumbnail_width"`
+	Video           map[string]struct {
+		Height  uint32 `json:"height"`
+		Width   uint32 `json:"width"`
 		VideoId string `json:"video_id"`
 	} `json:"video"`
 	VideoType string `json:"video_type"`
@@ -195,22 +195,22 @@ type VideoPost struct {
 // Post subtype
 type PhotoPost struct {
 	Post
-	ImagePermalink string `json:"image_permalink"`
-	Photos []Photo `json:"photos"`
+	ImagePermalink string  `json:"image_permalink"`
+	Photos         []Photo `json:"photos"`
 }
 
 // Photo post substructure
 type Photo struct {
-	AltSizes []PhotoSize `json:"alt_sizes"`
-	Caption string `json:"caption"`
-	OriginalSize PhotoSize `json:"original_size"`
+	AltSizes     []PhotoSize `json:"alt_sizes"`
+	Caption      string      `json:"caption"`
+	OriginalSize PhotoSize   `json:"original_size"`
 }
 
 // Photo substructure
 type PhotoSize struct {
 	Height uint32 `json:"height"`
-	Width uint32 `json:"width"`
-	Url string `json:"url"`
+	Width  uint32 `json:"width"`
+	Url    string `json:"url"`
 }
 
 // Convenience method for ease of use- renders a Post as a JSON string
@@ -219,15 +219,15 @@ func (p *Post) String() string {
 }
 
 // Convenience method for easy retrieval of one-off values
-func (p *Post) GetProperty(key string) (interface{},error) {
-	if field,exists := reflect.TypeOf(p).Elem().FieldByName(key); exists {
+func (p *Post) GetProperty(key string) (interface{}, error) {
+	if field, exists := reflect.TypeOf(p).Elem().FieldByName(key); exists {
 		return reflect.ValueOf(p).Elem().FieldByIndex(field.Index), nil
 	}
 	return nil, errors.New(fmt.Sprintf("Property %s does not exist", key))
 }
 
 // Useful for converting a PostInterface into a Post
-func (p *Post) GetSelf() (*Post) {
+func (p *Post) GetSelf() *Post {
 	return p
 }
 
@@ -279,9 +279,9 @@ func doPost(client ClientInterface, path, blogName string, params url.Values) (*
 		return nil, err
 	}
 	post := struct {
-		Response struct{
-				 Id uint64 `json:"id"`
-			 } `json:"response"`
+		Response struct {
+			Id uint64 `json:"id"`
+		} `json:"response"`
 	}{}
 	if err = json.Unmarshal(response.body, &post); err == nil {
 		ref := NewPostRefById(client, post.Response.Id)
@@ -292,7 +292,7 @@ func doPost(client ClientInterface, path, blogName string, params url.Values) (*
 }
 
 // Creates a PostRef with the given properties set
-func NewPostRefById(client ClientInterface, id uint64) (*PostRef) {
+func NewPostRefById(client ClientInterface, id uint64) *PostRef {
 	return &PostRef{
 		client: client,
 		MiniPost: MiniPost{
@@ -302,15 +302,15 @@ func NewPostRefById(client ClientInterface, id uint64) (*PostRef) {
 }
 
 // Creates a PostRef with the given properties set
-func NewPostRef(client ClientInterface, post *MiniPost) (*PostRef) {
+func NewPostRef(client ClientInterface, post *MiniPost) *PostRef {
 	return &PostRef{
-		client: client,
+		client:   client,
 		MiniPost: *post,
 	}
 }
 
 // Sets PostRef's client
-func (r *PostRef)SetClient(c ClientInterface) {
+func (r *PostRef) SetClient(c ClientInterface) {
 	r.client = c
 }
 

--- a/post.go
+++ b/post.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 )
 
-// Representation of a list of Posts
+// Posts represents a list of MiniPosts, which have a minimal set of information.
 type Posts struct {
 	client      ClientInterface
 	response    Response
@@ -17,7 +17,7 @@ type Posts struct {
 	TotalPosts  int64      `json:"total_posts"`
 }
 
-// Method to retrieve fully fleshed post data from stubs and cache result
+// All will retrieve fully fleshed post data from stubs and cache result.
 func (p *Posts) All() ([]PostInterface, error) {
 	var err error = nil
 	if p.parsedPosts == nil {
@@ -36,7 +36,7 @@ func (p *Posts) All() ([]PostInterface, error) {
 	return p.parsedPosts, err
 }
 
-// Method to retrieve a single Post entity at a given index; returns nil if index is out of bounds
+// Get retrieves a single Post entity at a given index or returns nil if index is out of bounds.
 func (p *Posts) Get(index uint) PostInterface {
 	if posts, err := p.All(); err == nil {
 		if index >= uint(len(posts)) {
@@ -47,7 +47,7 @@ func (p *Posts) Get(index uint) PostInterface {
 	return nil
 }
 
-// The basics for what is needed in a Post
+// MiniPost stores the basics for what is needed in a Post.
 type MiniPost struct {
 	Id        uint64 `json:"id"`
 	Type      string `json:"type"`
@@ -55,13 +55,13 @@ type MiniPost struct {
 	ReblogKey string `json:"reblog_key"`
 }
 
-// Starting point for performing operations on a post
+// PostRef is a base struct used as a starting point for performing operations on a post.
 type PostRef struct {
 	MiniPost
 	client ClientInterface
 }
 
-// The common fields on any post, no matter what type
+// Post holds the common fields of any post type.
 type Post struct {
 	PostRef
 	Body             string        `json:"body"`
@@ -98,7 +98,7 @@ type Post struct {
 	Trail             []ReblogTrailItem `json:"trail"`
 }
 
-// Post substructure
+// ReblogTrailItem represents an item in the "trail" to the original, root Post.
 type ReblogTrailItem struct {
 	Blog          Blog   `json:"blog"`
 	Content       string `json:"content"`
@@ -110,20 +110,20 @@ type ReblogTrailItem struct {
 	} `json:"post"`
 }
 
-// PostInterface for use in typed structures which could contain any of the below subtypes
+// PostInterface is the interface for any concrete Post type to retrieve a property.
 type PostInterface interface {
 	GetProperty(key string) (interface{}, error)
 	GetSelf() *Post
 }
 
-// Post subtype
+// QuotePost represents a Quote Post.
 type QuotePost struct {
 	Post
 	Source string `json:"source,omitempty"`
 	Text   string `json:"text"`
 }
 
-// Post subtype
+// ChatPost represents a Chat Post.
 type ChatPost struct {
 	Post
 	Dialog []struct {
@@ -133,13 +133,13 @@ type ChatPost struct {
 	} `json:"dialog"`
 }
 
-// Post subtype
+// TextPost represents a Text Post.
 type TextPost struct {
 	Post
 	Title string `json:"title"`
 }
 
-// Post subtype
+// LinkPost represents a Link Post.
 type LinkPost struct {
 	Post
 	Description string `json:"description"`
@@ -149,7 +149,7 @@ type LinkPost struct {
 	Url         string `json:"url"`
 }
 
-// Post subtype
+// AnswerPost represents an Answer Post.
 type AnswerPost struct {
 	Post
 	Answer     string `json:"answer"`
@@ -159,7 +159,7 @@ type AnswerPost struct {
 	Question   string `json:"question"`
 }
 
-// Post subtype
+// AudioPost represents an Audio Post.
 type AudioPost struct {
 	Post
 	AlbumArt       string `json:"album_art"`
@@ -172,7 +172,7 @@ type AudioPost struct {
 	Plays          uint64 `json:"plays"`
 }
 
-// Post subtype
+// VideoPost represents a Video Post.
 type VideoPost struct {
 	Post
 	Html5Capable bool   `json:"html5_capable"`
@@ -192,21 +192,21 @@ type VideoPost struct {
 	VideoType string `json:"video_type"`
 }
 
-// Post subtype
+// PhotoPost represents a Photo Post.
 type PhotoPost struct {
 	Post
 	ImagePermalink string  `json:"image_permalink"`
 	Photos         []Photo `json:"photos"`
 }
 
-// Photo post substructure
+// Photo represents one photo in a PhotoPost.
 type Photo struct {
 	AltSizes     []PhotoSize `json:"alt_sizes"`
 	Caption      string      `json:"caption"`
 	OriginalSize PhotoSize   `json:"original_size"`
 }
 
-// Photo substructure
+// PhotoSize represents a particular size for a Photo.
 type PhotoSize struct {
 	Height uint32 `json:"height"`
 	Width  uint32 `json:"width"`
@@ -235,12 +235,12 @@ func (sb *StringOrBool) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// Convenience method for ease of use- renders a Post as a JSON string
+// String returns the Post as a JSON string.
 func (p *Post) String() string {
 	return jsonStringify(*p)
 }
 
-// Convenience method for easy retrieval of one-off values
+// GetProperty uses reflection to retrieve one-off field values.
 func (p *Post) GetProperty(key string) (interface{}, error) {
 	if field, exists := reflect.TypeOf(p).Elem().FieldByName(key); exists {
 		return reflect.ValueOf(p).Elem().FieldByIndex(field.Index), nil
@@ -248,7 +248,7 @@ func (p *Post) GetProperty(key string) (interface{}, error) {
 	return nil, errors.New(fmt.Sprintf("Property %s does not exist", key))
 }
 
-// Useful for converting a PostInterface into a Post
+// GetSelf returns the Post from a PostInterface.
 func (p *Post) GetSelf() *Post {
 	return p
 }
@@ -271,22 +271,22 @@ func queryPosts(client ClientInterface, path, name string, params url.Values) (*
 	return nil, err
 }
 
-// Retrieve a blog's posts, in the API docs you can find how to filter by ID, type, etc
+// GetPosts retrieves a blog's posts, in the API docs you can find how to filter by ID, type, etc.
 func GetPosts(client ClientInterface, name string, params url.Values) (*Posts, error) {
 	return queryPosts(client, "/blog/%s/posts", name, params)
 }
 
-// Retrieve a blog's Queue
+// GetQueue retrieves a blog's queued posts.
 func GetQueue(client ClientInterface, name string, params url.Values) (*Posts, error) {
 	return queryPosts(client, "/blog/%s/posts/queue", name, params)
 }
 
-// Retrieve a blog's drafts
+// GetDrafts retrieves a blog's draft posts.
 func GetDrafts(client ClientInterface, name string, params url.Values) (*Posts, error) {
 	return queryPosts(client, "/blog/%s/posts/draft", name, params)
 }
 
-// Retrieve a blog's submsisions
+// GetSubmissions retrieves a blog's submission posts.
 func GetSubmissions(client ClientInterface, name string, params url.Values) (*Posts, error) {
 	return queryPosts(client, "/blog/%s/posts/submission", name, params)
 }
@@ -313,7 +313,7 @@ func doPost(client ClientInterface, path, blogName string, params url.Values) (*
 	return nil, err
 }
 
-// Creates a PostRef with the given properties set
+// NewPostRefById creates a PostRef for the id.
 func NewPostRefById(client ClientInterface, id uint64) *PostRef {
 	return &PostRef{
 		client: client,
@@ -323,7 +323,7 @@ func NewPostRefById(client ClientInterface, id uint64) *PostRef {
 	}
 }
 
-// Creates a PostRef with the given properties set
+// NewPostRef creates a PostRef for the MiniPost.
 func NewPostRef(client ClientInterface, post *MiniPost) *PostRef {
 	return &PostRef{
 		client:   client,
@@ -331,28 +331,28 @@ func NewPostRef(client ClientInterface, post *MiniPost) *PostRef {
 	}
 }
 
-// Sets PostRef's client
+// SetClient sets the client member of the PostRef.
 func (r *PostRef) SetClient(c ClientInterface) {
 	r.client = c
 }
 
-// Create a post, return the ID on success, error on failure
+// CreatePost will create a Post on tumblr for the blog in name.
 func CreatePost(client ClientInterface, name string, params url.Values) (*PostRef, error) {
 	return doPost(client, "/blog/%s/post", name, params)
 }
 
-// Edit a given post, returns nil if successful, error on failure
+// EditPost will update a Post on tumblr for the blog in name and Post in postId.
 func EditPost(client ClientInterface, blogName string, postId uint64, params url.Values) error {
 	_, err := client.PostWithParams(blogPath("/blog/%s/post/edit", blogName), setPostId(postId, params))
 	return err
 }
 
-// Convenience method to allow calling post.Edit(params)
+// Edit will update this Post on tumblr.
 func (p *PostRef) Edit(params url.Values) error {
 	return EditPost(p.client, p.BlogName, p.Id, params)
 }
 
-// Reblog a given post to the given blog, returns the reblog's post id if successful, else the error
+// ReblogPost will reblog the post in postId and reblogKey to the blog blogName.
 func ReblogPost(client ClientInterface, blogName string, postId uint64, reblogKey string, params url.Values) (*PostRef, error) {
 	if reblogKey == "" {
 		return nil, errors.New("No reblog key provided")
@@ -361,18 +361,18 @@ func ReblogPost(client ClientInterface, blogName string, postId uint64, reblogKe
 	return doPost(client, "/blog/%s/post/reblog", blogName, setPostId(postId, params))
 }
 
-// Convenience method to allow calling post.Reblog(params)
+// ReblogOnBlog will reblog this Post to the blog in name.
 func (p *PostRef) ReblogOnBlog(name string, params url.Values) (*PostRef, error) {
 	return ReblogPost(p.client, name, p.Id, p.ReblogKey, params)
 }
 
-// Delete a given blog's post by ID, nil if successful, error on failure
+// DeletePost will delete a Post on tumblr for the blog in name and Post in postId.
 func DeletePost(client ClientInterface, name string, postId uint64) error {
 	_, err := client.PostWithParams(blogPath("/blog/%s/post/delete", name), setPostId(postId, url.Values{}))
 	return err
 }
 
-// Convenience method to allow calling post.Delete()
+// Delete will delete this Post on tumblr.
 func (p *PostRef) Delete() error {
 	return DeletePost(p.client, p.BlogName, p.Id)
 }
@@ -400,12 +400,12 @@ func makePostFromType(t string) (PostInterface, error) {
 	return &Post{}, errors.New(fmt.Sprintf("Unknown type %s", t))
 }
 
-// Likes a Post on behalf of the current user
+// Like will like this Post on behalf of the current user.
 func (p *PostRef) Like() error {
 	return LikePost(p.client, p.Id, p.ReblogKey)
 }
 
-// Unlikes a Post on behalf of the current user
+// Unlikes will unlike a Post on behalf of the current user.
 func (p *PostRef) Unlike() error {
 	return UnlikePost(p.client, p.Id, p.ReblogKey)
 }


### PR DESCRIPTION
This fixes #6, video post player[].embed_code can be a string or boolean, this defines a type `StringOrBool` with a custom UnmarshalJSON function.

I also ran this file through `gofmt`.

This test code demonstrates the broken behavior and verifies this fix.

```go
package main

import (
	"log"
	"net/url"
	"os"

	tumblr "github.com/tumblr/tumblr.go"
	tumblr_go "github.com/tumblr/tumblrclient.go"
)

func main() {
	consumer_key := os.Getenv("TUMBLR_CONSUMER_KEY")
	consumer_secret := os.Getenv("TUMBLR_CONSUMER_SECRET")
	token := os.Getenv("TUMBLR_TOKEN")
	token_secret := os.Getenv("TUMBLR_TOKEN_SECRET")

	client := tumblr_go.NewClientWithToken(consumer_key, consumer_secret, token, token_secret)

	get(client, "animetube", "163255975138")
	get(client, "animetube", "163255974438")
}

func get(client *tumblr_go.Client, blogname, post_id string) {
	params := url.Values{}
	params.Set("id", post_id)
	resp, err := tumblr.GetPosts(client, blogname, params)
	if err != nil {
		log.Fatal(err)
	}

	allPosts, err := resp.All()
	if err != nil {
		log.Fatal(err)
	}

	for _, p := range allPosts {
		switch pt := p.(type) {
		case *tumblr.VideoPost:
			for _, y := range pt.Players {
				log.Print(y)
			}
		}
	}
	log.Println("---")
}
```

@ceyko 