### PR TITLE
Add missing Root item for trail

### DIFF
--- a/post.go
+++ b/post.go
@@ -104,6 +104,7 @@ type ReblogTrailItem struct {
 	Content       string `json:"content"`
 	ContentRaw    string `json:"content_raw"`
 	IsCurrentItem bool   `json:"is_current_item"`
+	IsRootItem    bool   `json:"is_root_item,omitempty"`
 	Post          struct {
 		// sometimes an actual int, sometimes a numeric string, always a headache
 		Id interface{} `json:"id"`


### PR DESCRIPTION
This adds the missing root item to the reblog trail so that you can find the origin of a post.

This is a replacement pull request of my closed pr #4 