### PR TITLE
VideoPost.duration using type float32.

### DIFF
--- a/post.go
+++ b/post.go
@@ -190,9 +190,9 @@ type VideoPost struct {
 		Width   uint32 `json:"width"`
 		VideoId string `json:"video_id"`
 	} `json:"video"`
-	VideoType string `json:"video_type"`
-	VideoUrl  string `json:"video_url"`
-	Duration  uint32 `json:"duration"`
+	VideoType string  `json:"video_type"`
+	VideoUrl  string  `json:"video_url"`
+	Duration  float32 `json:"duration"`
 }
 
 // PhotoPost represents a Photo Post.


### PR DESCRIPTION
Sometimes the duration of video returned is float, and it caused the following error:

```
json: cannot unmarshal number 148.49000000000001 into Go struct field VideoPost.duration of type uint32
```