### PR TITLE
User dashboard api support before_id param.

### DIFF
--- a/client.go
+++ b/client.go
@@ -29,13 +29,13 @@ type ClientInterface interface {
 }
 
 // shortcut for the most common case
-func setPostId(id uint64, params url.Values) url.Values {
-	return setParamsUint(id, params, "id")
+func setPostId(id int, params url.Values) url.Values {
+	return setParamsInt(id, params, "id")
 }
 
 // convenience function for setting an int
-func setParamsUint(id uint64, params url.Values, key string) url.Values {
-	params.Set(key, strconv.FormatUint(id, 10))
+func setParamsInt(id int, params url.Values, key string) url.Values {
+	params.Set(key, strconv.FormatInt(int64(id), 10))
 	return params
 }
 

--- a/dashboard.go
+++ b/dashboard.go
@@ -20,13 +20,13 @@ type Dashboard struct {
 func GetDashboard(client ClientInterface, params url.Values) (*Dashboard, error) {
 	cnt := 0
 	if params.Get("offset") != "" {
-		cnt++;
+		cnt++
 	}
 	if params.Get("since_id") != "" {
-		cnt++;
+		cnt++
 	}
 	if params.Get("before_id") != "" {
-		cnt++;
+		cnt++
 	}
 	if cnt > 1 {
 		return nil, errors.New("Only can specify one of offset, since_id and before_id")
@@ -76,7 +76,7 @@ func (d *Dashboard) NextBySinceId() (*Dashboard, error) {
 		return nil, NoNextPageError
 	}
 	lastId := d.Posts[size-1].GetSelf().Id
-	params := setParamsUint(lastId, copyParams(d.params), "since_id")
+	params := setParamsInt(lastId, copyParams(d.params), "since_id")
 	return GetDashboard(d.client, params)
 }
 
@@ -90,7 +90,7 @@ func (d *Dashboard) NextByBeforeId() (*Dashboard, error) {
 		return nil, NoNextPageError
 	}
 	lastId := d.Posts[size-1].GetSelf().Id
-	params := setParamsUint(lastId, copyParams(d.params), "before_id")
+	params := setParamsInt(lastId, copyParams(d.params), "before_id")
 	return GetDashboard(d.client, params)
 }
 

--- a/dashboard.go
+++ b/dashboard.go
@@ -12,13 +12,24 @@ type Dashboard struct {
 	params   url.Values
 	bySince  bool
 	byOffset bool
+	byBefore bool
 	Posts    []PostInterface `json:"posts"`
 }
 
 // Retreive a User's dashboard
 func GetDashboard(client ClientInterface, params url.Values) (*Dashboard, error) {
-	if params.Get("offset") != "" && params.Get("since_id") != "" {
-		return nil, errors.New("Cannot specify both offset and since_id")
+	cnt := 0
+	if params.Get("offset") != "" {
+		cnt++;
+	}
+	if params.Get("since_id") != "" {
+		cnt++;
+	}
+	if params.Get("before_id") != "" {
+		cnt++;
+	}
+	if cnt > 1 {
+		return nil, errors.New("Only can specify one of offset, since_id and before_id")
 	}
 
 	response, err := client.GetWithParams("/user/dashboard", params)
@@ -42,6 +53,7 @@ func GetDashboard(client ClientInterface, params url.Values) (*Dashboard, error)
 			params:   params,
 			byOffset: params.Get("offset") != "",
 			bySince:  params.Get("since_id") != "",
+			byBefore: params.Get("before_id") != "",
 		},
 	}
 	full.Response.Posts = makePostsFromMinis(minis, client)
@@ -56,7 +68,7 @@ var MixedPaginationMethodsError error = errors.New("Cannot mix pagination betwee
 
 // Returns the next page of a user's dashboard using the current page's last Post id
 func (d *Dashboard) NextBySinceId() (*Dashboard, error) {
-	if d.byOffset {
+	if !d.bySince {
 		return nil, MixedPaginationMethodsError
 	}
 	size := len(d.Posts)
@@ -68,9 +80,23 @@ func (d *Dashboard) NextBySinceId() (*Dashboard, error) {
 	return GetDashboard(d.client, params)
 }
 
+// Returns the next page of a user's dashboard using the current page's last Post id
+func (d *Dashboard) NextByBeforeId() (*Dashboard, error) {
+	if !d.byBefore {
+		return nil, MixedPaginationMethodsError
+	}
+	size := len(d.Posts)
+	if size < 1 {
+		return nil, NoNextPageError
+	}
+	lastId := d.Posts[size-1].GetSelf().Id
+	params := setParamsUint(lastId, copyParams(d.params), "before_id")
+	return GetDashboard(d.client, params)
+}
+
 // Returns the next page of a user's dashboard using the current page's offset
 func (d *Dashboard) NextByOffset() (*Dashboard, error) {
-	if d.bySince {
+	if !d.byOffset {
 		return nil, MixedPaginationMethodsError
 	}
 	if len(d.Posts) < 1 {

--- a/followers.go
+++ b/followers.go
@@ -9,27 +9,27 @@ import (
 
 type FollowingList struct {
 	client ClientInterface
-	Total  int64  `json:"total_blogs"`
+	Total  int    `json:"total_blogs"`
 	Blogs  []Blog `json:"blogs"`
-	offset int64
-	limit  int64
+	offset int
+	limit  int
 }
 
 // Object from the lsit of followers response
 type FollowerList struct {
 	client    ClientInterface
-	Total     int64      `json:"total_users"`
+	Total     int        `json:"total_users"`
 	Followers []Follower `json:"users"`
 	name      string
-	offset    int64
-	limit     int64
+	offset    int
+	limit     int
 }
 
 // FollowerList substructure
 type Follower struct {
 	Following bool   `json:"following"`
 	Name      string `json:"name"`
-	Updated   int64  `json:"updated"`
+	Updated   int    `json:"updated"`
 	Url       string `json:"url"`
 }
 
@@ -39,8 +39,8 @@ func GetFollowing(client ClientInterface, params url.Values) (*FollowingList, er
 	if err != nil {
 		return nil, err
 	}
-	limit, _ := strconv.ParseInt(params.Get("limit"), 10, 64)
-	offset, _ := strconv.ParseInt(params.Get("offset"), 10, 64)
+	limit, _ := strconv.Atoi(params.Get("limit"))
+	offset, _ := strconv.Atoi(params.Get("offset"))
 	response := struct {
 		Response FollowingList `json:"response"`
 	}{
@@ -62,8 +62,8 @@ func GetFollowingOfBlog(client ClientInterface, name string, params url.Values) 
 	if err != nil {
 		return nil, err
 	}
-	limit, _ := strconv.ParseInt(params.Get("limit"), 10, 64)
-	offset, _ := strconv.ParseInt(params.Get("offset"), 10, 64)
+	limit, _ := strconv.Atoi(params.Get("limit"))
+	offset, _ := strconv.Atoi(params.Get("offset"))
 	response := struct {
 		Response FollowingList `json:"response"`
 	}{
@@ -83,7 +83,7 @@ func GetFollowingOfBlog(client ClientInterface, name string, params url.Values) 
 func (f *FollowingList) Next() (*FollowingList, error) {
 	limit := f.limit
 	if limit < 1 {
-		limit = int64(len(f.Blogs))
+		limit = int(len(f.Blogs))
 	}
 	offset := f.offset + limit
 	if offset >= f.Total {
@@ -102,7 +102,7 @@ func (f *FollowingList) Prev() (*FollowingList, error) {
 	}
 	limit := f.limit
 	if limit < 1 {
-		limit = int64(len(f.Blogs))
+		limit = int(len(f.Blogs))
 	}
 	var newOffset = f.offset - limit
 	if limit >= f.offset {
@@ -120,8 +120,8 @@ func GetFollowers(client ClientInterface, name string, params url.Values) (*Foll
 	if err != nil {
 		return nil, err
 	}
-	limit, _ := strconv.ParseInt(params.Get("limit"), 10, 64)
-	offset, _ := strconv.ParseInt(params.Get("offset"), 10, 64)
+	limit, _ := strconv.Atoi(params.Get("limit"))
+	offset, _ := strconv.Atoi(params.Get("offset"))
 	followers := struct {
 		Followers FollowerList `json:"response"`
 	}{
@@ -142,10 +142,10 @@ func GetFollowers(client ClientInterface, name string, params url.Values) (*Foll
 func (f *FollowerList) Next() (*FollowerList, error) {
 	limit := f.limit
 	if limit < 1 {
-		limit = int64(len(f.Followers))
+		limit = int(len(f.Followers))
 	}
 	offset := f.offset + limit
-	if int64(offset) >= f.Total || len(f.Followers) < 1 {
+	if int(offset) >= f.Total || len(f.Followers) < 1 {
 		return nil, NoNextPageError
 	}
 	params := url.Values{}
@@ -161,7 +161,7 @@ func (f *FollowerList) Prev() (*FollowerList, error) {
 	}
 	limit := f.limit
 	if limit < 1 {
-		limit = int64(len(f.Followers))
+		limit = int(len(f.Followers))
 	}
 	offset := f.offset - limit
 	if limit >= f.offset {

--- a/followers.go
+++ b/followers.go
@@ -2,15 +2,17 @@ package tumblr
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/url"
+	"strconv"
 )
 
 type FollowingList struct {
 	client ClientInterface
 	Total  int64  `json:"total_blogs"`
 	Blogs  []Blog `json:"blogs"`
-	offset uint
-	limit  uint
+	offset int64
+	limit  int64
 }
 
 // Object from the lsit of followers response
@@ -19,8 +21,8 @@ type FollowerList struct {
 	Total     int64      `json:"total_users"`
 	Followers []Follower `json:"users"`
 	name      string
-	offset    uint
-	limit     uint
+	offset    int64
+	limit     int64
 }
 
 // FollowerList substructure
@@ -32,13 +34,36 @@ type Follower struct {
 }
 
 // Retrieves the list of blogs this user follows
-func GetFollowing(client ClientInterface, offset, limit uint) (*FollowingList, error) {
-	params := setParamsUint(uint64(limit), url.Values{}, "limit")
-	params = setParamsUint(uint64(offset), params, "offset")
+func GetFollowing(client ClientInterface, params url.Values) (*FollowingList, error) {
 	result, err := client.GetWithParams("/user/following", params)
 	if err != nil {
 		return nil, err
 	}
+	limit, _ := strconv.ParseInt(params.Get("limit"), 10, 64)
+	offset, _ := strconv.ParseInt(params.Get("offset"), 10, 64)
+	response := struct {
+		Response FollowingList `json:"response"`
+	}{
+		Response: FollowingList{
+			client: client,
+			limit:  limit,
+			offset: offset,
+		},
+	}
+	if err = json.Unmarshal(result.body, &response); err != nil {
+		return nil, err
+	}
+	return &response.Response, nil
+}
+
+// GetFollowingOfBlog comment
+func GetFollowingOfBlog(client ClientInterface, name string, params url.Values) (*FollowingList, error) {
+	result, err := client.GetWithParams(blogPath("/blog/%s/following", name), params)
+	if err != nil {
+		return nil, err
+	}
+	limit, _ := strconv.ParseInt(params.Get("limit"), 10, 64)
+	offset, _ := strconv.ParseInt(params.Get("offset"), 10, 64)
 	response := struct {
 		Response FollowingList `json:"response"`
 	}{
@@ -58,13 +83,16 @@ func GetFollowing(client ClientInterface, offset, limit uint) (*FollowingList, e
 func (f *FollowingList) Next() (*FollowingList, error) {
 	limit := f.limit
 	if limit < 1 {
-		limit = uint(len(f.Blogs))
+		limit = int64(len(f.Blogs))
 	}
 	offset := f.offset + limit
-	if offset >= uint(f.Total) {
+	if offset >= f.Total {
 		return nil, NoNextPageError
 	}
-	return GetFollowing(f.client, offset, limit)
+	params := url.Values{}
+	params.Add("limit", fmt.Sprintf("%d", limit))
+	params.Add("offset", fmt.Sprintf("%d", offset))
+	return GetFollowing(f.client, params)
 }
 
 // Retrieves the previous page of followers
@@ -74,23 +102,26 @@ func (f *FollowingList) Prev() (*FollowingList, error) {
 	}
 	limit := f.limit
 	if limit < 1 {
-		limit = uint(len(f.Blogs))
+		limit = int64(len(f.Blogs))
 	}
-	var newOffset uint = f.offset - limit
+	var newOffset = f.offset - limit
 	if limit >= f.offset {
 		newOffset = 0
 	}
-	return GetFollowing(f.client, newOffset, limit)
+	params := url.Values{}
+	params.Add("limit", fmt.Sprintf("%d", limit))
+	params.Add("offset", fmt.Sprintf("%d", newOffset))
+	return GetFollowing(f.client, params)
 }
 
 // Retrieve User's followers
-func GetFollowers(client ClientInterface, name string, offset, limit uint) (*FollowerList, error) {
-	params := setParamsUint(uint64(offset), url.Values{}, "offset")
-	params = setParamsUint(uint64(limit), params, "limit")
+func GetFollowers(client ClientInterface, name string, params url.Values) (*FollowerList, error) {
 	response, err := client.GetWithParams(blogPath("/blog/%s/followers", name), params)
 	if err != nil {
 		return nil, err
 	}
+	limit, _ := strconv.ParseInt(params.Get("limit"), 10, 64)
+	offset, _ := strconv.ParseInt(params.Get("offset"), 10, 64)
 	followers := struct {
 		Followers FollowerList `json:"response"`
 	}{
@@ -111,13 +142,16 @@ func GetFollowers(client ClientInterface, name string, offset, limit uint) (*Fol
 func (f *FollowerList) Next() (*FollowerList, error) {
 	limit := f.limit
 	if limit < 1 {
-		limit = uint(len(f.Followers))
+		limit = int64(len(f.Followers))
 	}
 	offset := f.offset + limit
 	if int64(offset) >= f.Total || len(f.Followers) < 1 {
 		return nil, NoNextPageError
 	}
-	return GetFollowers(f.client, f.name, offset, limit)
+	params := url.Values{}
+	params.Add("limit", fmt.Sprintf("%d", limit))
+	params.Add("offset", fmt.Sprintf("%d", offset))
+	return GetFollowers(f.client, f.name, params)
 }
 
 // Get previous page of a user's followers
@@ -127,13 +161,16 @@ func (f *FollowerList) Prev() (*FollowerList, error) {
 	}
 	limit := f.limit
 	if limit < 1 {
-		limit = uint(len(f.Followers))
+		limit = int64(len(f.Followers))
 	}
 	offset := f.offset - limit
 	if limit >= f.offset {
 		offset = 0
 	}
-	return GetFollowers(f.client, f.name, offset, limit)
+	params := url.Values{}
+	params.Add("limit", fmt.Sprintf("%d", limit))
+	params.Add("offset", fmt.Sprintf("%d", offset))
+	return GetFollowers(f.client, f.name, params)
 }
 
 // Follow a blog

--- a/followers.go
+++ b/followers.go
@@ -7,7 +7,7 @@ import (
 
 type FollowingList struct {
 	client ClientInterface
-	Total  uint32 `json:"total_blogs"`
+	Total  int64  `json:"total_blogs"`
 	Blogs  []Blog `json:"blogs"`
 	offset uint
 	limit  uint
@@ -16,7 +16,7 @@ type FollowingList struct {
 // Object from the lsit of followers response
 type FollowerList struct {
 	client    ClientInterface
-	Total     uint32     `json:"total_users"`
+	Total     int64      `json:"total_users"`
 	Followers []Follower `json:"users"`
 	name      string
 	offset    uint
@@ -114,7 +114,7 @@ func (f *FollowerList) Next() (*FollowerList, error) {
 		limit = uint(len(f.Followers))
 	}
 	offset := f.offset + limit
-	if uint32(offset) >= f.Total || len(f.Followers) < 1 {
+	if int64(offset) >= f.Total || len(f.Followers) < 1 {
 		return nil, NoNextPageError
 	}
 	return GetFollowers(f.client, f.name, offset, limit)

--- a/likes.go
+++ b/likes.go
@@ -10,7 +10,7 @@ type Likes struct {
 	response    *Response
 	parsedPosts []PostInterface
 	Posts       []MiniPost `json:"liked_posts"`
-	TotalLikes  int64      `json:"liked_count"`
+	TotalLikes  int        `json:"liked_count"`
 }
 
 // Retrieves a Users's list of Posts they have liked
@@ -55,7 +55,7 @@ func GetLikesOfBlog(client ClientInterface, name string, params url.Values) (*Li
 }
 
 // Convenience method for performing a like/unlike operation
-func doLike(client ClientInterface, path string, postId uint64, reblogKey string) error {
+func doLike(client ClientInterface, path string, postId int, reblogKey string) error {
 	params := url.Values{}
 	params.Set("reblog_key", reblogKey)
 	_, err := client.PostWithParams(path, setPostId(postId, params))
@@ -63,12 +63,12 @@ func doLike(client ClientInterface, path string, postId uint64, reblogKey string
 }
 
 // Like a post on behalf of a user
-func LikePost(client ClientInterface, postId uint64, reblogKey string) error {
+func LikePost(client ClientInterface, postId int, reblogKey string) error {
 	return doLike(client, "/user/like", postId, reblogKey)
 }
 
 // Unlike a post on behalf of a user
-func UnlikePost(client ClientInterface, postId uint64, reblogKey string) error {
+func UnlikePost(client ClientInterface, postId int, reblogKey string) error {
 	return doLike(client, "/user/unlike", postId, reblogKey)
 }
 

--- a/likes.go
+++ b/likes.go
@@ -36,6 +36,24 @@ func GetLikes(client ClientInterface, params url.Values) (*Likes, error) {
 	return &result.Response, nil
 }
 
+// GetLikesOfBlog comment
+func GetLikesOfBlog(client ClientInterface, name string, params url.Values) (*Likes, error) {
+	response, err := client.GetWithParams(blogPath("/blog/%s/likes", name), params)
+	if err != nil {
+		return nil, err
+	}
+
+	result := struct {
+		Response Likes `json:"response"`
+	}{}
+	if err = json.Unmarshal(response.body, &result); err != nil {
+		return nil, err
+	}
+	result.Response.client = client
+	result.Response.response = &response
+	return &result.Response, nil
+}
+
 // Convenience method for performing a like/unlike operation
 func doLike(client ClientInterface, path string, postId uint64, reblogKey string) error {
 	params := url.Values{}

--- a/likes.go
+++ b/likes.go
@@ -10,7 +10,7 @@ type Likes struct {
 	response    *Response
 	parsedPosts []PostInterface
 	Posts       []MiniPost `json:"liked_posts"`
-	TotalLikes  uint64     `json:"liked_count"`
+	TotalLikes  int64      `json:"liked_count"`
 }
 
 // Retrieves a Users's list of Posts they have liked

--- a/post.go
+++ b/post.go
@@ -76,7 +76,7 @@ type Post struct {
 	Format           string        `json:"format"`
 	Highlighted      []interface{} `json:"highlighted"`
 	Liked            bool          `json:"liked"`
-	NoteCount        uint64        `json:"note_count"`
+	NoteCount        int64         `json:"note_count"`
 	PermalinkUrl     string        `json:"permalink_url"`
 	PostUrl          string        `json:"post_url"`
 	Reblog           struct {
@@ -170,7 +170,7 @@ type AudioPost struct {
 	AudioUrl       string `json:"audio_url"`
 	Embed          string `json:"embed"`
 	Player         string `json:"player"`
-	Plays          uint64 `json:"plays"`
+	Plays          int64  `json:"plays"`
 }
 
 // VideoPost represents a Video Post.

--- a/post.go
+++ b/post.go
@@ -94,6 +94,7 @@ type Post struct {
 	Tags              []string          `json:"tags"`
 	Timestamp         uint64            `json:"timestamp"`
 	FeaturedTimestamp uint64            `json:"featured_timestamp,omitempty"`
+	LikedTimestamp    uint64            `json:"liked_timestamp,omitempty"`
 	TrackName         string            `json:"track_name,omitempty"`
 	Trail             []ReblogTrailItem `json:"trail"`
 }

--- a/post.go
+++ b/post.go
@@ -14,7 +14,7 @@ type Posts struct {
 	response    Response
 	parsedPosts []PostInterface
 	Posts       []MiniPost `json:"posts"`
-	TotalPosts  int64      `json:"total_posts"`
+	TotalPosts  int        `json:"total_posts"`
 }
 
 // All will retrieve fully fleshed post data from stubs and cache result.
@@ -37,9 +37,9 @@ func (p *Posts) All() ([]PostInterface, error) {
 }
 
 // Get retrieves a single Post entity at a given index or returns nil if index is out of bounds.
-func (p *Posts) Get(index uint) PostInterface {
+func (p *Posts) Get(index int) PostInterface {
 	if posts, err := p.All(); err == nil {
-		if index >= uint(len(posts)) {
+		if index >= len(posts) {
 			return nil
 		}
 		return posts[index]
@@ -49,7 +49,7 @@ func (p *Posts) Get(index uint) PostInterface {
 
 // MiniPost stores the basics for what is needed in a Post.
 type MiniPost struct {
-	Id        uint64 `json:"id"`
+	Id        int    `json:"id"`
 	Type      string `json:"type"`
 	BlogName  string `json:"blog_name"`
 	ReblogKey string `json:"reblog_key"`
@@ -76,7 +76,7 @@ type Post struct {
 	Format           string        `json:"format"`
 	Highlighted      []interface{} `json:"highlighted"`
 	Liked            bool          `json:"liked"`
-	NoteCount        int64         `json:"note_count"`
+	NoteCount        int           `json:"note_count"`
 	PermalinkUrl     string        `json:"permalink_url"`
 	PostUrl          string        `json:"post_url"`
 	Reblog           struct {
@@ -92,9 +92,9 @@ type Post struct {
 	State             string            `json:"state"`
 	Summary           string            `json:"summary"`
 	Tags              []string          `json:"tags"`
-	Timestamp         uint64            `json:"timestamp"`
-	FeaturedTimestamp uint64            `json:"featured_timestamp,omitempty"`
-	LikedTimestamp    uint64            `json:"liked_timestamp,omitempty"`
+	Timestamp         int               `json:"timestamp"`
+	FeaturedTimestamp int               `json:"featured_timestamp,omitempty"`
+	LikedTimestamp    int               `json:"liked_timestamp,omitempty"`
 	TrackName         string            `json:"track_name,omitempty"`
 	Trail             []ReblogTrailItem `json:"trail"`
 }
@@ -171,7 +171,7 @@ type AudioPost struct {
 	AudioUrl       string `json:"audio_url"`
 	Embed          string `json:"embed"`
 	Player         string `json:"player"`
-	Plays          int64  `json:"plays"`
+	Plays          int    `json:"plays"`
 }
 
 // VideoPost represents a Video Post.
@@ -183,12 +183,12 @@ type VideoPost struct {
 		EmbedCode StringOrBool `json:"embed_code"`
 		Width     interface{}  `json:"width"`
 	} `json:"player"`
-	ThumbnailHeight uint32 `json:"thumbnail_height"`
+	ThumbnailHeight int    `json:"thumbnail_height"`
 	ThumbnailUrl    string `json:"thumbnail_url"`
-	ThumbnailWidth  uint32 `json:"thumbnail_width"`
+	ThumbnailWidth  int    `json:"thumbnail_width"`
 	Video           map[string]struct {
-		Height  uint32 `json:"height"`
-		Width   uint32 `json:"width"`
+		Height  int    `json:"height"`
+		Width   int    `json:"width"`
 		VideoId string `json:"video_id"`
 	} `json:"video"`
 	VideoType string  `json:"video_type"`
@@ -212,8 +212,8 @@ type Photo struct {
 
 // PhotoSize represents a particular size for a Photo.
 type PhotoSize struct {
-	Height uint32 `json:"height"`
-	Width  uint32 `json:"width"`
+	Height int    `json:"height"`
+	Width  int    `json:"width"`
 	Url    string `json:"url"`
 }
 
@@ -306,7 +306,7 @@ func doPost(client ClientInterface, path, blogName string, params url.Values) (*
 	}
 	post := struct {
 		Response struct {
-			Id uint64 `json:"id"`
+			Id int `json:"id"`
 		} `json:"response"`
 	}{}
 	if err = json.Unmarshal(response.body, &post); err == nil {
@@ -318,7 +318,7 @@ func doPost(client ClientInterface, path, blogName string, params url.Values) (*
 }
 
 // NewPostRefById creates a PostRef for the id.
-func NewPostRefById(client ClientInterface, id uint64) *PostRef {
+func NewPostRefById(client ClientInterface, id int) *PostRef {
 	return &PostRef{
 		client: client,
 		MiniPost: MiniPost{
@@ -346,7 +346,7 @@ func CreatePost(client ClientInterface, name string, params url.Values) (*PostRe
 }
 
 // EditPost will update a Post on tumblr for the blog in name and Post in postId.
-func EditPost(client ClientInterface, blogName string, postId uint64, params url.Values) error {
+func EditPost(client ClientInterface, blogName string, postId int, params url.Values) error {
 	_, err := client.PostWithParams(blogPath("/blog/%s/post/edit", blogName), setPostId(postId, params))
 	return err
 }
@@ -357,7 +357,7 @@ func (p *PostRef) Edit(params url.Values) error {
 }
 
 // ReblogPost will reblog the post in postId and reblogKey to the blog blogName.
-func ReblogPost(client ClientInterface, blogName string, postId uint64, reblogKey string, params url.Values) (*PostRef, error) {
+func ReblogPost(client ClientInterface, blogName string, postId int, reblogKey string, params url.Values) (*PostRef, error) {
 	if reblogKey == "" {
 		return nil, errors.New("No reblog key provided")
 	}
@@ -371,7 +371,7 @@ func (p *PostRef) ReblogOnBlog(name string, params url.Values) (*PostRef, error)
 }
 
 // DeletePost will delete a Post on tumblr for the blog in name and Post in postId.
-func DeletePost(client ClientInterface, name string, postId uint64) error {
+func DeletePost(client ClientInterface, name string, postId int) error {
 	_, err := client.PostWithParams(blogPath("/blog/%s/post/delete", name), setPostId(postId, url.Values{}))
 	return err
 }

--- a/search.go
+++ b/search.go
@@ -50,6 +50,6 @@ func (s *SearchResults) Next() (*SearchResults, error) {
 		lastTs = lastPost.Timestamp
 	}
 	params := s.params
-	params.Set("before", strconv.FormatUint(lastTs, 10))
+	params.Set("before", strconv.FormatInt(int64(lastTs), 10))
 	return TaggedSearch(s.client, params.Get("tag"), params)
 }

--- a/tumblelog.go
+++ b/tumblelog.go
@@ -20,7 +20,7 @@ type ShortBlog struct {
 	Url            string `json:"url"`
 	Title          string `json:"title"`
 	IsPrimary      bool   `json:"primary"`
-	FollowerCount  int64  `json:"followers"`
+	FollowerCount  int    `json:"followers"`
 	PostToTwitter  string `json:"tweet"`
 	PostToFacebook string `json:"facebook"`
 	Visibility     string `json:"type"`
@@ -31,7 +31,7 @@ type Blog struct {
 	BlogRef
 	Url                  string `json:"url"`
 	Title                string `json:"title"`
-	Posts                int64  `json:"posts"`
+	Posts                int    `json:"posts"`
 	Ask                  bool   `json:"ask"`
 	AskAnon              bool   `json:"ask_anon"`
 	AskAnonPageTitle     string `json:"ask_page_title"`
@@ -45,11 +45,11 @@ type Blog struct {
 	ShareLikes           bool   `json:"share_likes"`
 	SubmissionPageTitle  string `json:"submission_page_title"`
 	Subscribed           bool   `json:"subscribed"`
-	TotalPosts           int64  `json:"total_posts"`
-	Updated              int64  `json:"updated"`
+	TotalPosts           int    `json:"total_posts"`
+	Updated              int    `json:"updated"`
 	Name                 string `json:"name"`
-	Followers            int64  `json:"followers"`
-	Likes                int64  `json:"likes"`
+	Followers            int    `json:"followers"`
+	Likes                int    `json:"likes"`
 	Primary              bool   `json:"primary"`
 }
 

--- a/tumblelog.go
+++ b/tumblelog.go
@@ -80,7 +80,7 @@ func GetBlogInfo(client ClientInterface, name string) (*Blog, error) {
 
 // Retrieve Blog's Avatar URI
 func GetAvatar(client ClientInterface, name string) (string, error) {
-	response, err := client.Get(blogPath("/blog/%s/avatar", name))
+	response, err := client.Get(blogPath("/blog/%s/avatar/512", name))
 	if err != nil {
 		return "", err
 	}
@@ -118,7 +118,8 @@ func (b *BlogRef) GetAvatar() (string, error) {
 
 // Retrieves blog's followers for the given blog reference
 func (b *BlogRef) GetFollowers() (*FollowerList, error) {
-	return GetFollowers(b.client, b.Name, 0, 0)
+	params := url.Values{}
+	return GetFollowers(b.client, b.Name, params)
 }
 
 // Retrieves blog's posts for the given blog reference

--- a/tumblelog.go
+++ b/tumblelog.go
@@ -20,7 +20,7 @@ type ShortBlog struct {
 	Url            string `json:"url"`
 	Title          string `json:"title"`
 	IsPrimary      bool   `json:"primary"`
-	FollowerCount  uint32 `json:"followers"`
+	FollowerCount  int64  `json:"followers"`
 	PostToTwitter  string `json:"tweet"`
 	PostToFacebook string `json:"facebook"`
 	Visibility     string `json:"type"`
@@ -47,6 +47,10 @@ type Blog struct {
 	Subscribed           bool   `json:"subscribed"`
 	TotalPosts           int64  `json:"total_posts"`
 	Updated              int64  `json:"updated"`
+	Name                 string `json:"name"`
+	Followers            int64  `json:"followers"`
+	Likes                int64  `json:"likes"`
+	Primary              bool   `json:"primary"`
 }
 
 // Convenience method converting a Blog into a JSON representation

--- a/user.go
+++ b/user.go
@@ -5,11 +5,11 @@ import (
 )
 
 type User struct {
-	Following         uint32      `json:"following"`
-	DefaultPostFormat string      `json:"default_post_format"`
-	Name              string      `json:"name"`
-	Likes             uint64      `json:"likes"`
-	Blogs             []ShortBlog `json:"blogs"`
+	Following         int64  `json:"following"`
+	DefaultPostFormat string `json:"default_post_format"`
+	Name              string `json:"name"`
+	Likes             int64  `json:"likes"`
+	Blogs             []Blog `json:"blogs"`
 }
 
 // Retrieves the current user's info (based on the client's token/secret values)

--- a/user.go
+++ b/user.go
@@ -5,10 +5,10 @@ import (
 )
 
 type User struct {
-	Following         int64  `json:"following"`
+	Following         int    `json:"following"`
 	DefaultPostFormat string `json:"default_post_format"`
 	Name              string `json:"name"`
-	Likes             int64  `json:"likes"`
+	Likes             int    `json:"likes"`
 	Blogs             []Blog `json:"blogs"`
 }
 


### PR DESCRIPTION
Found this param in Tumblr google group's [post](https://groups.google.com/forum/#!searchin/tumblr-api/since_id%7Csort:date/tumblr-api/STUcJXqMpsI/kLnkTo8XfkkJ). Use before_id to fetch older posts and avoid the order changing problem of using offset param.