### PR TITLE
update contributor license agreement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,13 @@ We want to make contributing to Tumblr's Go Wrapper as easy and transparent as p
 
 ## Contributor License Agreement ("CLA")
 
-In order to accept your pull request, we need you to submit a CLA.
+In order to accept your contribution, we need you to submit a CLA. If you open
+a pull request, a bot will automatically check if you have already submitted
+one. If not it will ask you to do so by visiting a link and signing in with
+GitHub.
 
-Complete your CLA [here](http://static.tumblr.com/zyubucd/GaTngbrpr/tumblr_corporate_contributor_license_agreement_v1__10-7-14.pdf) (a more integrated web form is coming soon).
+The CLA, contact information, and GitHub sign-in can be found here:
+[https://yahoocla.herokuapp.com](https://yahoocla.herokuapp.com).
 
 ## License
 


### PR DESCRIPTION
This updates `CONTRIBUTING.md` to point to our [contributor license agreement form](https://yahoocla.herokuapp.com/).

@tumblr/security 